### PR TITLE
add GET requests for trade endpoints

### DIFF
--- a/Trade Demo.ipynb
+++ b/Trade Demo.ipynb
@@ -1,0 +1,492 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3",
+   "language": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from poandy.controller.account import AccountController\n",
+    "from poandy.controller.order import OrderController\n",
+    "from poandy.controller.trade import TradeController\n",
+    "\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "account_id = AccountController.get_default_account_id()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create orders\n",
+    "for _ in range(5):\n",
+    "    OrderController.create_order(\n",
+    "        account_id, \"MARKET\", \"100\", \"USD_CAD\", \"FOK\", \"DEFAULT\"\n",
+    "    )"
+   ]
+  },
+  {
+   "source": [
+    "# get_trades\n",
+    "\n",
+    "Get a list of Trades for an account\n",
+    "\n",
+    "- `account_id`: (str), required\n",
+    "- `state`: (str), optional\n",
+    "    - The state to filter the requested Trade by. Must be either OPEN, CLOSED, CLOSE_WHEN_TRADEABLE, or ALL \\[default=OPEN\\]\n",
+    "- `instrument`: (str), optional\n",
+    "    - The instrument to filter the requested Trades by\n",
+    "- `count`: (int), optional\n",
+    "    - The maximum number of Trades to return \\[default=50, maximum=500\\]"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "{'trades': [{'id': '773',\n",
+       "   'instrument': 'USD_CAD',\n",
+       "   'price': '1.26251',\n",
+       "   'openTime': '1613453318.930210668',\n",
+       "   'initialUnits': '100',\n",
+       "   'initialMarginRequired': '6.6154',\n",
+       "   'state': 'OPEN',\n",
+       "   'currentUnits': '100',\n",
+       "   'realizedPL': '0.0000',\n",
+       "   'financing': '0.0000',\n",
+       "   'dividendAdjustment': '0.0000',\n",
+       "   'unrealizedPL': '-0.0158',\n",
+       "   'marginUsed': '6.6154'},\n",
+       "  {'id': '771',\n",
+       "   'instrument': 'USD_CAD',\n",
+       "   'price': '1.26251',\n",
+       "   'openTime': '1613453318.637060708',\n",
+       "   'initialUnits': '100',\n",
+       "   'initialMarginRequired': '6.6154',\n",
+       "   'state': 'OPEN',\n",
+       "   'currentUnits': '100',\n",
+       "   'realizedPL': '0.0000',\n",
+       "   'financing': '0.0000',\n",
+       "   'dividendAdjustment': '0.0000',\n",
+       "   'unrealizedPL': '-0.0158',\n",
+       "   'marginUsed': '6.6154'},\n",
+       "  {'id': '769',\n",
+       "   'instrument': 'USD_CAD',\n",
+       "   'price': '1.26251',\n",
+       "   'openTime': '1613453318.355961217',\n",
+       "   'initialUnits': '100',\n",
+       "   'initialMarginRequired': '6.6154',\n",
+       "   'state': 'OPEN',\n",
+       "   'currentUnits': '100',\n",
+       "   'realizedPL': '0.0000',\n",
+       "   'financing': '0.0000',\n",
+       "   'dividendAdjustment': '0.0000',\n",
+       "   'unrealizedPL': '-0.0158',\n",
+       "   'marginUsed': '6.6154'},\n",
+       "  {'id': '767',\n",
+       "   'instrument': 'USD_CAD',\n",
+       "   'price': '1.26251',\n",
+       "   'openTime': '1613453318.085578600',\n",
+       "   'initialUnits': '100',\n",
+       "   'initialMarginRequired': '6.6154',\n",
+       "   'state': 'OPEN',\n",
+       "   'currentUnits': '100',\n",
+       "   'realizedPL': '0.0000',\n",
+       "   'financing': '0.0000',\n",
+       "   'dividendAdjustment': '0.0000',\n",
+       "   'unrealizedPL': '-0.0158',\n",
+       "   'marginUsed': '6.6154'},\n",
+       "  {'id': '765',\n",
+       "   'instrument': 'USD_CAD',\n",
+       "   'price': '1.26251',\n",
+       "   'openTime': '1613453317.810690619',\n",
+       "   'initialUnits': '100',\n",
+       "   'initialMarginRequired': '6.6154',\n",
+       "   'state': 'OPEN',\n",
+       "   'currentUnits': '100',\n",
+       "   'realizedPL': '0.0000',\n",
+       "   'financing': '0.0000',\n",
+       "   'dividendAdjustment': '0.0000',\n",
+       "   'unrealizedPL': '-0.0158',\n",
+       "   'marginUsed': '6.6154'}],\n",
+       " 'lastTransactionID': '773'}"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 4
+    }
+   ],
+   "source": [
+    "# default only show OPEN trades\n",
+    "TradeController.get_trades(account_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "    id instrument    price              openTime initialUnits  \\\n",
+       "0  785    USD_CAD  1.26260  1613453471.176451067          100   \n",
+       "1  783    USD_CAD  1.26260  1613453470.917470974          100   \n",
+       "2  781    USD_CAD  1.26260  1613453470.643450394          100   \n",
+       "3  779    USD_CAD  1.26260  1613453470.366790382          100   \n",
+       "4  777    USD_CAD  1.26260  1613453470.069669930          100   \n",
+       "\n",
+       "  initialMarginRequired state currentUnits realizedPL financing  \\\n",
+       "0                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "1                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "2                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "3                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "4                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "\n",
+       "  dividendAdjustment unrealizedPL marginUsed  \n",
+       "0             0.0000      -0.0042     6.6166  \n",
+       "1             0.0000      -0.0042     6.6166  \n",
+       "2             0.0000      -0.0042     6.6166  \n",
+       "3             0.0000      -0.0042     6.6166  \n",
+       "4             0.0000      -0.0042     6.6166  "
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>id</th>\n      <th>instrument</th>\n      <th>price</th>\n      <th>openTime</th>\n      <th>initialUnits</th>\n      <th>initialMarginRequired</th>\n      <th>state</th>\n      <th>currentUnits</th>\n      <th>realizedPL</th>\n      <th>financing</th>\n      <th>dividendAdjustment</th>\n      <th>unrealizedPL</th>\n      <th>marginUsed</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>785</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453471.176451067</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6166</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>783</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.917470974</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6166</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>781</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.643450394</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6166</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>779</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.366790382</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6166</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>777</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.069669930</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6166</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 5
+    }
+   ],
+   "source": [
+    "# nice formatting with pandas dataframe\n",
+    "pd.DataFrame(TradeController.get_trades(account_id)[\"trades\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "    id instrument    price              openTime initialUnits  \\\n",
+       "0  785    USD_CAD  1.26260  1613453471.176451067          100   \n",
+       "1  783    USD_CAD  1.26260  1613453470.917470974          100   \n",
+       "2  781    USD_CAD  1.26260  1613453470.643450394          100   \n",
+       "3  779    USD_CAD  1.26260  1613453470.366790382          100   \n",
+       "4  777    USD_CAD  1.26260  1613453470.069669930          100   \n",
+       "5  773    USD_CAD  1.26251  1613453318.930210668          100   \n",
+       "6  771    USD_CAD  1.26251  1613453318.637060708          100   \n",
+       "7  769    USD_CAD  1.26251  1613453318.355961217          100   \n",
+       "8  767    USD_CAD  1.26251  1613453318.085578600          100   \n",
+       "9  765    USD_CAD  1.26251  1613453317.810690619          100   \n",
+       "\n",
+       "  initialMarginRequired   state currentUnits realizedPL financing  \\\n",
+       "0                6.6162    OPEN          100     0.0000    0.0000   \n",
+       "1                6.6162    OPEN          100     0.0000    0.0000   \n",
+       "2                6.6162    OPEN          100     0.0000    0.0000   \n",
+       "3                6.6162    OPEN          100     0.0000    0.0000   \n",
+       "4                6.6162    OPEN          100     0.0000    0.0000   \n",
+       "5                6.6154  CLOSED            0    -0.0253    0.0000   \n",
+       "6                6.6154  CLOSED            0    -0.0253    0.0000   \n",
+       "7                6.6154  CLOSED            0    -0.0253    0.0000   \n",
+       "8                6.6154  CLOSED            0    -0.0253    0.0000   \n",
+       "9                6.6154  CLOSED            0    -0.0253    0.0000   \n",
+       "\n",
+       "  dividendAdjustment unrealizedPL marginUsed closingTransactionIDs  \\\n",
+       "0             0.0000      -0.0053     6.6164                   NaN   \n",
+       "1             0.0000      -0.0053     6.6164                   NaN   \n",
+       "2             0.0000      -0.0053     6.6164                   NaN   \n",
+       "3             0.0000      -0.0053     6.6164                   NaN   \n",
+       "4             0.0000      -0.0053     6.6164                   NaN   \n",
+       "5             0.0000          NaN        NaN                 [775]   \n",
+       "6             0.0000          NaN        NaN                 [775]   \n",
+       "7             0.0000          NaN        NaN                 [775]   \n",
+       "8             0.0000          NaN        NaN                 [775]   \n",
+       "9             0.0000          NaN        NaN                 [775]   \n",
+       "\n",
+       "              closeTime averageClosePrice  \n",
+       "0                   NaN               NaN  \n",
+       "1                   NaN               NaN  \n",
+       "2                   NaN               NaN  \n",
+       "3                   NaN               NaN  \n",
+       "4                   NaN               NaN  \n",
+       "5  1613453345.603663772           1.26227  \n",
+       "6  1613453345.603663772           1.26227  \n",
+       "7  1613453345.603663772           1.26227  \n",
+       "8  1613453345.603663772           1.26227  \n",
+       "9  1613453345.603663772           1.26227  "
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>id</th>\n      <th>instrument</th>\n      <th>price</th>\n      <th>openTime</th>\n      <th>initialUnits</th>\n      <th>initialMarginRequired</th>\n      <th>state</th>\n      <th>currentUnits</th>\n      <th>realizedPL</th>\n      <th>financing</th>\n      <th>dividendAdjustment</th>\n      <th>unrealizedPL</th>\n      <th>marginUsed</th>\n      <th>closingTransactionIDs</th>\n      <th>closeTime</th>\n      <th>averageClosePrice</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>785</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453471.176451067</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0053</td>\n      <td>6.6164</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>783</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.917470974</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0053</td>\n      <td>6.6164</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>781</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.643450394</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0053</td>\n      <td>6.6164</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>779</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.366790382</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0053</td>\n      <td>6.6164</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>777</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.069669930</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0053</td>\n      <td>6.6164</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>773</td>\n      <td>USD_CAD</td>\n      <td>1.26251</td>\n      <td>1613453318.930210668</td>\n      <td>100</td>\n      <td>6.6154</td>\n      <td>CLOSED</td>\n      <td>0</td>\n      <td>-0.0253</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>[775]</td>\n      <td>1613453345.603663772</td>\n      <td>1.26227</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>771</td>\n      <td>USD_CAD</td>\n      <td>1.26251</td>\n      <td>1613453318.637060708</td>\n      <td>100</td>\n      <td>6.6154</td>\n      <td>CLOSED</td>\n      <td>0</td>\n      <td>-0.0253</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>[775]</td>\n      <td>1613453345.603663772</td>\n      <td>1.26227</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>769</td>\n      <td>USD_CAD</td>\n      <td>1.26251</td>\n      <td>1613453318.355961217</td>\n      <td>100</td>\n      <td>6.6154</td>\n      <td>CLOSED</td>\n      <td>0</td>\n      <td>-0.0253</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>[775]</td>\n      <td>1613453345.603663772</td>\n      <td>1.26227</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>767</td>\n      <td>USD_CAD</td>\n      <td>1.26251</td>\n      <td>1613453318.085578600</td>\n      <td>100</td>\n      <td>6.6154</td>\n      <td>CLOSED</td>\n      <td>0</td>\n      <td>-0.0253</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>[775]</td>\n      <td>1613453345.603663772</td>\n      <td>1.26227</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>765</td>\n      <td>USD_CAD</td>\n      <td>1.26251</td>\n      <td>1613453317.810690619</td>\n      <td>100</td>\n      <td>6.6154</td>\n      <td>CLOSED</td>\n      <td>0</td>\n      <td>-0.0253</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>[775]</td>\n      <td>1613453345.603663772</td>\n      <td>1.26227</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 6
+    }
+   ],
+   "source": [
+    "# show ALL trades (open and closed trades)\n",
+    "pd.DataFrame(TradeController.get_trades(account_id, state=\"ALL\", count=10)[\"trades\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "    id instrument    price              openTime initialUnits  \\\n",
+       "0  785    USD_CAD  1.26260  1613453471.176451067          100   \n",
+       "1  783    USD_CAD  1.26260  1613453470.917470974          100   \n",
+       "2  781    USD_CAD  1.26260  1613453470.643450394          100   \n",
+       "3  779    USD_CAD  1.26260  1613453470.366790382          100   \n",
+       "4  777    USD_CAD  1.26260  1613453470.069669930          100   \n",
+       "\n",
+       "  initialMarginRequired state currentUnits realizedPL financing  \\\n",
+       "0                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "1                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "2                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "3                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "4                6.6162  OPEN          100     0.0000    0.0000   \n",
+       "\n",
+       "  dividendAdjustment unrealizedPL marginUsed  \n",
+       "0             0.0000      -0.0042     6.6164  \n",
+       "1             0.0000      -0.0042     6.6164  \n",
+       "2             0.0000      -0.0042     6.6164  \n",
+       "3             0.0000      -0.0042     6.6164  \n",
+       "4             0.0000      -0.0042     6.6164  "
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>id</th>\n      <th>instrument</th>\n      <th>price</th>\n      <th>openTime</th>\n      <th>initialUnits</th>\n      <th>initialMarginRequired</th>\n      <th>state</th>\n      <th>currentUnits</th>\n      <th>realizedPL</th>\n      <th>financing</th>\n      <th>dividendAdjustment</th>\n      <th>unrealizedPL</th>\n      <th>marginUsed</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>785</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453471.176451067</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6164</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>783</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.917470974</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6164</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>781</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.643450394</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6164</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>779</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.366790382</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6164</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>777</td>\n      <td>USD_CAD</td>\n      <td>1.26260</td>\n      <td>1613453470.069669930</td>\n      <td>100</td>\n      <td>6.6162</td>\n      <td>OPEN</td>\n      <td>100</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>0.0000</td>\n      <td>-0.0042</td>\n      <td>6.6164</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 7
+    }
+   ],
+   "source": [
+    "# same as the default .get_trades() method\n",
+    "pd.DataFrame(TradeController.get_open_trades(account_id)[\"trades\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "{'trade': {'id': '785',\n",
+       "  'instrument': 'USD_CAD',\n",
+       "  'price': '1.26260',\n",
+       "  'openTime': '1613453471.176451067',\n",
+       "  'initialUnits': '100',\n",
+       "  'initialMarginRequired': '6.6162',\n",
+       "  'state': 'OPEN',\n",
+       "  'currentUnits': '100',\n",
+       "  'realizedPL': '0.0000',\n",
+       "  'financing': '0.0000',\n",
+       "  'dividendAdjustment': '0.0000',\n",
+       "  'unrealizedPL': '0.0052',\n",
+       "  'marginUsed': '6.6168'},\n",
+       " 'lastTransactionID': '785'}"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 8
+    }
+   ],
+   "source": [
+    "# get details about a specific trade\n",
+    "trades = TradeController.get_open_trades(account_id)\n",
+    "trade_id = trades[\"trades\"][0][\"id\"]\n",
+    "\n",
+    "TradeController.get_specific_trade(account_id, trade_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "{'orderCreateTransaction': {'id': '786',\n",
+       "  'accountID': '101-003-16380380-001',\n",
+       "  'userID': 16380380,\n",
+       "  'batchID': '786',\n",
+       "  'requestID': '78824908875623832',\n",
+       "  'time': '1613453587.887421672',\n",
+       "  'type': 'MARKET_ORDER',\n",
+       "  'instrument': 'USD_CAD',\n",
+       "  'units': '-500',\n",
+       "  'timeInForce': 'FOK',\n",
+       "  'positionFill': 'DEFAULT',\n",
+       "  'reason': 'CLIENT_ORDER'},\n",
+       " 'orderFillTransaction': {'id': '787',\n",
+       "  'accountID': '101-003-16380380-001',\n",
+       "  'userID': 16380380,\n",
+       "  'batchID': '786',\n",
+       "  'requestID': '78824908875623832',\n",
+       "  'time': '1613453587.887421672',\n",
+       "  'type': 'ORDER_FILL',\n",
+       "  'orderID': '786',\n",
+       "  'instrument': 'USD_CAD',\n",
+       "  'units': '-500',\n",
+       "  'requestedUnits': '-500',\n",
+       "  'price': '1.26265',\n",
+       "  'pl': '0.0260',\n",
+       "  'quotePL': '0.02500',\n",
+       "  'financing': '0.0000',\n",
+       "  'baseFinancing': '0.00000000000000',\n",
+       "  'commission': '0.0000',\n",
+       "  'accountBalance': '194055.0954',\n",
+       "  'gainQuoteHomeConversionFactor': '1.04279980',\n",
+       "  'lossQuoteHomeConversionFactor': '1.05328020',\n",
+       "  'guaranteedExecutionFee': '0.0000',\n",
+       "  'quoteGuaranteedExecutionFee': '0',\n",
+       "  'halfSpreadCost': '0.0340',\n",
+       "  'fullVWAP': '1.26265',\n",
+       "  'reason': 'MARKET_ORDER',\n",
+       "  'tradesClosed': [{'tradeID': '777',\n",
+       "    'units': '-100',\n",
+       "    'realizedPL': '0.0052',\n",
+       "    'financing': '0.0000',\n",
+       "    'baseFinancing': '0.00000000000000',\n",
+       "    'price': '1.26265',\n",
+       "    'guaranteedExecutionFee': '0.0000',\n",
+       "    'quoteGuaranteedExecutionFee': '0',\n",
+       "    'halfSpreadCost': '0.0068'},\n",
+       "   {'tradeID': '779',\n",
+       "    'units': '-100',\n",
+       "    'realizedPL': '0.0052',\n",
+       "    'financing': '0.0000',\n",
+       "    'baseFinancing': '0.00000000000000',\n",
+       "    'price': '1.26265',\n",
+       "    'guaranteedExecutionFee': '0.0000',\n",
+       "    'quoteGuaranteedExecutionFee': '0',\n",
+       "    'halfSpreadCost': '0.0068'},\n",
+       "   {'tradeID': '781',\n",
+       "    'units': '-100',\n",
+       "    'realizedPL': '0.0052',\n",
+       "    'financing': '0.0000',\n",
+       "    'baseFinancing': '0.00000000000000',\n",
+       "    'price': '1.26265',\n",
+       "    'guaranteedExecutionFee': '0.0000',\n",
+       "    'quoteGuaranteedExecutionFee': '0',\n",
+       "    'halfSpreadCost': '0.0068'},\n",
+       "   {'tradeID': '783',\n",
+       "    'units': '-100',\n",
+       "    'realizedPL': '0.0052',\n",
+       "    'financing': '0.0000',\n",
+       "    'baseFinancing': '0.00000000000000',\n",
+       "    'price': '1.26265',\n",
+       "    'guaranteedExecutionFee': '0.0000',\n",
+       "    'quoteGuaranteedExecutionFee': '0',\n",
+       "    'halfSpreadCost': '0.0068'},\n",
+       "   {'tradeID': '785',\n",
+       "    'units': '-100',\n",
+       "    'realizedPL': '0.0052',\n",
+       "    'financing': '0.0000',\n",
+       "    'baseFinancing': '0.00000000000000',\n",
+       "    'price': '1.26265',\n",
+       "    'guaranteedExecutionFee': '0.0000',\n",
+       "    'quoteGuaranteedExecutionFee': '0',\n",
+       "    'halfSpreadCost': '0.0068'}],\n",
+       "  'fullPrice': {'closeoutBid': '1.26261',\n",
+       "   'closeoutAsk': '1.26283',\n",
+       "   'timestamp': '1613453583.791944943',\n",
+       "   'bids': [{'price': '1.26265', 'liquidity': '1000000'},\n",
+       "    {'price': '1.26264', 'liquidity': '2000000'},\n",
+       "    {'price': '1.26263', 'liquidity': '2000000'},\n",
+       "    {'price': '1.26261', 'liquidity': '5000000'}],\n",
+       "   'asks': [{'price': '1.26278', 'liquidity': '1000000'},\n",
+       "    {'price': '1.26280', 'liquidity': '4000000'},\n",
+       "    {'price': '1.26283', 'liquidity': '5000000'}]},\n",
+       "  'homeConversionFactors': {'gainQuoteHome': {'factor': '1.04279980'},\n",
+       "   'lossQuoteHome': {'factor': '1.05328020'},\n",
+       "   'gainBaseHome': {'factor': '1.31674320'},\n",
+       "   'lossBaseHome': {'factor': '1.32997680'}}},\n",
+       " 'relatedTransactionIDs': ['786', '787'],\n",
+       " 'lastTransactionID': '787'}"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 9
+    }
+   ],
+   "source": [
+    "# close position\n",
+    "OrderController.create_order(\n",
+    "    account_id, \"MARKET\", \"-500\", \"USD_CAD\", \"FOK\", \"DEFAULT\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "{'trades': [], 'lastTransactionID': '787'}"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 10
+    }
+   ],
+   "source": [
+    "# make sure no open trades\n",
+    "TradeController.get_open_trades(account_id)"
+   ]
+  }
+ ]
+}

--- a/poandy/controller/trade.py
+++ b/poandy/controller/trade.py
@@ -1,0 +1,59 @@
+from poandy.util.request import RequestSender, RequestType
+from poandy.controller.base import Controller
+
+
+class TradeController(Controller):
+    @classmethod
+    def get_trades(
+        cls,
+        account_id,
+        ids=None,
+        state="OPEN",
+        instrument=None,
+        count=50,
+        beforeID=None,
+    ):
+        if state not in ["OPEN", "CLOSED", "CLOSE_WHEN_TRADEABLE", "ALL"]:
+            raise ValueError(
+                "state must be a valid TradeStateFilter (OPEN, CLOSED, CLOSE_WHEN_TRADEABLE, or ALL)"
+            )
+        if count < 1 or count > 500:
+            raise ValueError("count must be positive and not exceed 500")
+
+        url = f"{cls._config['base_url']}/v3/accounts/{account_id}/trades"
+        params = {"state": state, "count": count}
+        if ids:
+            # required format is csv
+            params["ids"] = ",".join(ids)
+        if instrument:
+            params["instrument"] = instrument
+        if beforeID:
+            params["beforeID"] = beforeID
+
+        response = RequestSender.send(url, cls._headers, RequestType.GET, params=params)
+        return (
+            response.json()
+            if response.status_code == 200
+            else response.raise_for_status()
+        )
+
+    @classmethod
+    def get_open_trades(cls, account_id):
+        url = f"{cls._config['base_url']}/v3/accounts/{account_id}/openTrades"
+        response = RequestSender.send(url, cls._headers, RequestType.GET)
+        return (
+            response.json()
+            if response.status_code == 200
+            else response.raise_for_status()
+        )
+
+    @classmethod
+    def get_specific_trade(cls, account_id, tradeSpecifier):
+        # tradeSpecifier is either TradeID or @ClientID
+        url = f"{cls._config['base_url']}/v3/accounts/{account_id}/trades/{tradeSpecifier}"
+        response = RequestSender.send(url, cls._headers, RequestType.GET)
+        return (
+            response.json()
+            if response.status_code == 200
+            else response.raise_for_status()
+        )

--- a/tests/test_trade.py
+++ b/tests/test_trade.py
@@ -1,0 +1,130 @@
+import pytest
+
+from poandy.controller.trade import TradeController
+from poandy.controller.order import OrderController
+from poandy.controller.account import AccountController
+
+
+class TestTradeController:
+    account_id = AccountController.get_default_account_id()
+    instrument = "USD_CAD"
+    # NOTE: if there are errors in creating orders (e.g. insufficient funds), the tests will fail
+    # NOTE: in some tests, if an assertions fails, the code to close position will not be executed
+
+    def test_get_trades_default(self):
+        # open position
+        order = OrderController.create_order(
+            self.account_id, "MARKET", "100", self.instrument, "FOK", "DEFAULT"
+        )
+        id = order["orderFillTransaction"]["tradeOpened"]["tradeID"]
+
+        trades = TradeController.get_trades(self.account_id)
+        assert isinstance(trades, dict)
+        assert "trades" in trades
+        assert "lastTransactionID" in trades
+        assert isinstance(trades["trades"], list)
+        assert trades["trades"][0]["id"] == id
+        assert trades["trades"][0]["instrument"] == self.instrument
+
+        # close position
+        OrderController.create_order(
+            self.account_id, "MARKET", "-100", "USD_CAD", "FOK", "DEFAULT"
+        )
+
+    def test_get_trades_with_params(self):
+        state = "CLOSED"
+        count = 10
+        ids = []
+
+        # create closed trades: buy then sell immediately
+        for _ in range(count):
+            order = OrderController.create_order(
+                self.account_id, "MARKET", "100", self.instrument, "FOK", "DEFAULT"
+            )
+            ids.append(order["orderFillTransaction"]["tradeOpened"]["tradeID"])
+        OrderController.create_order(
+            self.account_id,
+            "MARKET",
+            str(-100 * count),
+            self.instrument,
+            "FOK",
+            "DEFAULT",
+        )
+
+        trades = TradeController.get_trades(
+            self.account_id,
+            ids=ids,
+            state=state,
+            instrument=self.instrument,
+            count=count,
+        )
+        assert len(trades["trades"]) == count
+        for trade in trades["trades"]:
+            assert trade["id"] in ids
+            assert trade["state"] == state
+            assert trade["instrument"] == self.instrument
+
+        trades = TradeController.get_trades(
+            self.account_id,
+            ids=ids,
+            state=state,
+            instrument=self.instrument,
+            beforeID=ids[-1],
+        )
+        assert len(trades["trades"]) == count - 1  # beforeID is not included
+
+    def test_get_trades_with_invalid_params(self):
+        state = "TEST"
+        count = 600
+        with pytest.raises(ValueError):
+            TradeController.get_trades(self.account_id, state=state)
+            TradeController.get_trades(self.account_id, count=count)
+
+    def test_get_open_trades(self):
+        count = 10
+        ids = []
+        for _ in range(count):
+            order = OrderController.create_order(
+                self.account_id, "MARKET", "100", self.instrument, "FOK", "DEFAULT"
+            )
+            ids.append(order["orderFillTransaction"]["tradeOpened"]["tradeID"])
+
+        open_trades = TradeController.get_open_trades(self.account_id)
+        assert isinstance(open_trades, dict)
+        assert "trades" in open_trades
+        assert "lastTransactionID" in open_trades
+        assert isinstance(open_trades["trades"], list)
+        assert len(open_trades["trades"]) >= count
+        for trade in open_trades["trades"]:
+            assert trade["id"] in ids
+
+        # close position
+        OrderController.create_order(
+            self.account_id,
+            "MARKET",
+            str(-100 * count),
+            self.instrument,
+            "FOK",
+            "DEFAULT",
+        )
+
+    # NOTE: there must not be any trades when executing this test
+    def test_empty_get_open_trades(self):
+        open_trades = TradeController.get_open_trades(self.account_id)
+        assert len(open_trades["trades"]) == 0
+
+    def test_get_specific_trade(self):
+        # open position
+        order = OrderController.create_order(
+            self.account_id, "MARKET", "100", self.instrument, "FOK", "DEFAULT"
+        )
+        id = order["orderFillTransaction"]["tradeOpened"]["tradeID"]
+
+        trade = TradeController.get_specific_trade(self.account_id, tradeSpecifier=id)
+        assert trade["trade"]["id"] == id
+        assert trade["trade"]["instrument"] == self.instrument
+
+        # close position
+        order = OrderController.create_order(
+            self.account_id, "MARKET", "-100", self.instrument, "FOK", "DEFAULT"
+        )


### PR DESCRIPTION
Implement #11 with similar style as other Controllers
- implement `TradeController`, with `get_trades()` and `get_open_trades()`
- write tests for TradeController
- include a demo notebook for TradeController